### PR TITLE
Don't add explicitly the delays to the timestamps

### DIFF
--- a/src/csa/csaplanner.cpp
+++ b/src/csa/csaplanner.cpp
@@ -595,7 +595,7 @@ void CSA::Planner::planPage(Fragments::Page *page)
                                 true,
                                 profile->departureConnection()->departureDelay(),
                                 false,
-                                profile->departureConnection()->departureDelayedTime() < QDateTime::currentDateTime(),
+                                profile->departureConnection()->departureTime() < QDateTime::currentDateTime(),
                                 CSA::Vehicle::OccupancyLevel::UNSUPPORTED
                                 );
                     CSA::RouteLegEnd *arrivalLeg = new CSA::RouteLegEnd(
@@ -606,7 +606,7 @@ void CSA::Planner::planPage(Fragments::Page *page)
                                 true,
                                 profile->arrivalConnection()->departureDelay(),
                                 false,
-                                profile->arrivalConnection()->arrivalDelayedTime() < QDateTime::currentDateTime(),
+                                profile->arrivalConnection()->arrivalTime() < QDateTime::currentDateTime(),
                                 CSA::Vehicle::OccupancyLevel::UNSUPPORTED
                                 );
                     // Create vehicle information
@@ -641,7 +641,7 @@ void CSA::Planner::planPage(Fragments::Page *page)
                             true,
                             profile->departureConnection()->departureDelay(),
                             false,
-                            profile->departureConnection()->departureDelayedTime() < QDateTime::currentDateTime(),
+                            profile->departureConnection()->departureTime() < QDateTime::currentDateTime(),
                             CSA::Vehicle::OccupancyLevel::UNSUPPORTED
                             );
 
@@ -653,7 +653,7 @@ void CSA::Planner::planPage(Fragments::Page *page)
                             true,
                             profile->arrivalConnection()->departureDelay(),
                             false,
-                            profile->arrivalConnection()->arrivalDelayedTime() < QDateTime::currentDateTime(),
+                            profile->arrivalConnection()->arrivalTime() < QDateTime::currentDateTime(),
                             Vehicle::OccupancyLevel::UNSUPPORTED
                             );
 

--- a/src/csa/csaroute.cpp
+++ b/src/csa/csaroute.cpp
@@ -275,25 +275,11 @@ qint64 CSA::Route::duration() const
  * @file csaroute.cpp
  * @author Dylan Van Assche
  * @date 09 Aug 2018
- * @brief Gets the duration with delays
- * @return const qint64 durationWithDelays
- * @package CSA
- * @public
- * Gets the duration with the delays included of the route and returns it.
- */
-qint64 CSA::Route::durationWithDelays() const
-{
-    return this->departureDelayedTime().secsTo(this->arrivalDelayedTime());
-}
-
-/**
- * @file csaroute.cpp
- * @author Dylan Van Assche
- * @date 09 Aug 2018
  * @brief Gets the departure time
  * @return const QDateTime departureTime
  * @package CSA
  * @public
+ * @note Delays are already included in this timestamp.
  * Gets the departure time of the route and returns it.
  */
 QDateTime CSA::Route::departureTime() const
@@ -320,25 +306,11 @@ qint16 CSA::Route::departureDelay() const
  * @file csaroute.cpp
  * @author Dylan Van Assche
  * @date 09 Aug 2018
- * @brief Gets the departure time with delays
- * @return const QDateTime departureDelayedTime
- * @package CSA
- * @public
- * Gets the departure time with the delays included of the route and returns it.
- */
-QDateTime CSA::Route::departureDelayedTime() const
-{
-    return this->departureTime().addSecs(this->departureDelay());
-}
-
-/**
- * @file csaroute.cpp
- * @author Dylan Van Assche
- * @date 09 Aug 2018
  * @brief Gets the arrival time
  * @return const QDateTime arrivalTime
  * @package CSA
  * @public
+ * @note Delays are already included in this timestamp.
  * Gets the arrival time of the route and returns it.
  */
 QDateTime CSA::Route::arrivalTime() const
@@ -359,21 +331,6 @@ QDateTime CSA::Route::arrivalTime() const
 qint16 CSA::Route::arrivalDelay() const
 {
     return this->arrivalStation()->arrival()->delay();
-}
-
-/**
- * @file csaroute.cpp
- * @author Dylan Van Assche
- * @date 09 Aug 2018
- * @brief Gets the arrival time with delays
- * @return const QDateTime arrivalDelayedTime
- * @package CSA
- * @public
- * Gets the arrival time with the delays included of the route and returns it.
- */
-QDateTime CSA::Route::arrivalDelayedTime() const
-{
-    return this->arrivalTime().addSecs(this->arrivalDelay());
 }
 
 /**

--- a/src/fragments/fragmentsfragment.cpp
+++ b/src/fragments/fragmentsfragment.cpp
@@ -314,36 +314,6 @@ void Fragments::Fragment::setArrivalDelay(const qint16 &arrivalDelay)
 /**
  * @file fragmentsfragment.cpp
  * @author Dylan Van Assche
- * @date 30 Jul 2018
- * @brief Gets the delayed departure time of the linked connection fragment
- * @return const QDateTime departureDelayedTime
- * @package Fragments
- * @public
- * Retrieves the delayed departure time of the linked connection fragment and returns it.
- */
-QDateTime Fragments::Fragment::departureDelayedTime() const
-{
-    return (this->departureTime().addSecs(this->departureDelay()));
-}
-
-/**
- * @file fragmentsfragment.cpp
- * @author Dylan Van Assche
- * @date 30 Jul 2018
- * @brief Gets the delayed arrival time of the linked connection fragment
- * @return const QDateTime arrivalDelayedTime
- * @package Fragments
- * @public
- * Retrieves the delayed arrival time of the linked connection fragment and returns it.
- */
-QDateTime Fragments::Fragment::arrivalDelayedTime() const
-{
-    return (this->arrivalTime().addSecs(this->arrivalDelay()));
-}
-
-/**
- * @file fragmentsfragment.cpp
- * @author Dylan Van Assche
  * @date 21 Jul 2018
  * @brief Gets the trip URI of the linked connection fragment
  * @return const QUrl tripURI

--- a/src/include/csa/csaroute.h
+++ b/src/include/csa/csaroute.h
@@ -59,9 +59,7 @@ public:
     qint64 durationWithDelays() const;
     QDateTime departureTime() const;
     qint16 departureDelay() const;
-    QDateTime departureDelayedTime() const;
     QDateTime arrivalTime() const;
-    QDateTime arrivalDelayedTime()const;
     qint16 arrivalDelay() const;
     qint16 transferCount() const;
     qint16 stationCount() const;

--- a/src/include/fragments/fragmentsfragment.h
+++ b/src/include/fragments/fragmentsfragment.h
@@ -59,8 +59,6 @@ public:
     void setDepartureDelay(const qint16 &departureDelay);
     qint16 arrivalDelay() const;
     void setArrivalDelay(const qint16 &arrivalDelay);
-    QDateTime departureDelayedTime() const;
-    QDateTime arrivalDelayedTime() const;
     QUrl tripURI() const;
     void setTripURI(const QUrl &tripURI);
     QUrl routeURI() const;


### PR DESCRIPTION
1. **Explanation**: 
    - Don't add explicitly the delays to the timestamps, it's already included if you follow the Linked Connections standards: http://linkedconnections.org/specification/1-0

2. **Fixed issues**: 
    - Fixed #1 

3. **Testing environment**: 
    - Sailfish OS version: 2.2.0.29
    - Sailfish OS hardware: Jolla 1
