### PR TITLE
Enable nextResults() and previousResults() in routing

### DIFF
--- a/qrail.pri
+++ b/qrail.pri
@@ -49,7 +49,9 @@ SOURCES += \
     $$PWD/src/fragments/fragmentsdispatcher.cpp \
     $$PWD/src/qrail.cpp \
     $$PWD/src/engines/vehicle/vehiclenullvehicle.cpp \
-    $$PWD/src/engines/liveboard/liveboardnullboard.cpp
+    $$PWD/src/engines/liveboard/liveboardnullboard.cpp \
+    $$PWD/src/include/engines/router/routerjourney.cpp \
+    $$PWD/src/engines/router/routernulljourney.cpp
 
 HEADERS += \
     $$PWD/src/include/engines/alerts/alertsmessage.h \
@@ -60,6 +62,8 @@ HEADERS += \
     $$PWD/src/include/engines/router/routerroutelegend.h \
     $$PWD/src/include/engines/router/routerstationstopprofile.h \
     $$PWD/src/include/engines/router/routertrainprofile.h \
+    $$PWD/src/include/engines/router/routerjourney.h \
+    $$PWD/src/include/engines/router/routernulljourney.h \
     $$PWD/src/include/engines/liveboard/liveboardfactory.h \
     $$PWD/src/include/engines/liveboard/liveboardboard.h \
     $$PWD/src/include/engines/liveboard/liveboardnullboard.h \

--- a/qrail.pri
+++ b/qrail.pri
@@ -32,8 +32,12 @@ SOURCES += \
     $$PWD/src/engines/router/routerroutelegend.cpp \
     $$PWD/src/engines/router/routerstationstopprofile.cpp \
     $$PWD/src/engines/router/routertrainprofile.cpp \
+    $$PWD/src/engines/router/routerjourney.cpp \
+    $$PWD/src/engines/router/routernulljourney.cpp \
     $$PWD/src/engines/liveboard/liveboardfactory.cpp \
     $$PWD/src/engines/liveboard/liveboardboard.cpp \
+    $$PWD/src/engines/liveboard/liveboardnullboard.cpp \
+    $$PWD/src/engines/vehicle/vehiclenullvehicle.cpp \
     $$PWD/src/engines/station/stationstation.cpp \
     $$PWD/src/engines/station/stationnullstation.cpp \
     $$PWD/src/engines/station/stationfactory.cpp \
@@ -47,11 +51,7 @@ SOURCES += \
     $$PWD/src/fragments/fragmentspage.cpp \
     $$PWD/src/fragments/fragmentsfactory.cpp \
     $$PWD/src/fragments/fragmentsdispatcher.cpp \
-    $$PWD/src/qrail.cpp \
-    $$PWD/src/engines/vehicle/vehiclenullvehicle.cpp \
-    $$PWD/src/engines/liveboard/liveboardnullboard.cpp \
-    $$PWD/src/include/engines/router/routerjourney.cpp \
-    $$PWD/src/engines/router/routernulljourney.cpp
+    $$PWD/src/qrail.cpp
 
 HEADERS += \
     $$PWD/src/include/engines/alerts/alertsmessage.h \

--- a/qrail.pro
+++ b/qrail.pro
@@ -16,7 +16,7 @@
 #
 
 TARGET = qrail
-VERSION = 0.0.2
+VERSION = 0.0.4
 
 # Uncomment this config if you want to build a static library
 CONFIG += staticlib

--- a/src/engines/liveboard/liveboardboard.cpp
+++ b/src/engines/liveboard/liveboardboard.cpp
@@ -122,8 +122,6 @@ void QRail::LiveboardEngine::Board::setHydraNext(const QUrl &hydraNext)
         QDateTime timeOldHydraNext = QDateTime::fromString(
                                          queryOldHydraNext.queryItemValue("departureTime"), Qt::ISODate);
 
-        qDebug() << "HYDRA NEXT=" << hydraNext << timeNewHydraNext << "|" << this->hydraNext() <<
-                 timeOldHydraNext;
         // Only accept URI that's later in time
         if (timeNewHydraNext > timeOldHydraNext) {
             m_hydraNext = hydraNext;
@@ -132,7 +130,6 @@ void QRail::LiveboardEngine::Board::setHydraNext(const QUrl &hydraNext)
     }
     // Current hydraNext is still empty, setting it to the received hydraNext
     else {
-        qDebug() << "Empty hydraNext";
         m_hydraNext = hydraNext;
         emit this->hydraNextChanged();
     }
@@ -153,9 +150,6 @@ void QRail::LiveboardEngine::Board::setHydraPrevious(const QUrl &hydraPrevious)
                                              queryNewHydraPrevious.queryItemValue("departureTime"), Qt::ISODate);
         QDateTime timeOldHydraPrevious = QDateTime::fromString(
                                              queryOldHydraPrevious.queryItemValue("departureTime"), Qt::ISODate);
-        qDebug() << "HYDRA PREVIOUS=" << hydraPrevious << timeNewHydraPrevious << "|" <<
-                 this->hydraPrevious() <<
-                 timeOldHydraPrevious;
         // Only accept URI that's earlier in time
         if (timeNewHydraPrevious < timeOldHydraPrevious) {
             m_hydraPrevious = hydraPrevious;
@@ -164,7 +158,6 @@ void QRail::LiveboardEngine::Board::setHydraPrevious(const QUrl &hydraPrevious)
     }
     // Current hydraPrevious is still empty, setting it to the received hydraPrevious
     else {
-        qDebug() << "Empty hydraPrevious";
         m_hydraPrevious = hydraPrevious;
         emit this->hydraPreviousChanged();
     }

--- a/src/engines/liveboard/liveboardboard.cpp
+++ b/src/engines/liveboard/liveboardboard.cpp
@@ -55,6 +55,8 @@ QRail::LiveboardEngine::Board::Board(const QList<QRail::VehicleEngine::Vehicle *
     m_station = station;
     m_from = from;
     m_until = until;
+    m_hydraNext = QUrl();
+    m_hydraPrevious = QUrl();
 }
 
 /**

--- a/src/engines/router/routerjourney.cpp
+++ b/src/engines/router/routerjourney.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU General Public License
  *   along with QRail.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "routerjourney.h"
+#include "engines/router/routerjourney.h"
 using namespace QRail;
 
 RouterEngine::Journey::Journey(QObject *parent) : QObject(parent)
@@ -125,9 +125,6 @@ void RouterEngine::Journey::setHydraPrevious(const QUrl &hydraPrevious)
                                              queryNewHydraPrevious.queryItemValue("departureTime"), Qt::ISODate);
         QDateTime timeOldHydraPrevious = QDateTime::fromString(
                                              queryOldHydraPrevious.queryItemValue("departureTime"), Qt::ISODate);
-        qDebug() << "HYDRA PREVIOUS=" << hydraPrevious << timeNewHydraPrevious << "|" <<
-                 this->hydraPrevious() <<
-                 timeOldHydraPrevious;
         // Only accept URI that's earlier in time
         if (timeNewHydraPrevious < timeOldHydraPrevious) {
             m_hydraPrevious = hydraPrevious;
@@ -136,7 +133,6 @@ void RouterEngine::Journey::setHydraPrevious(const QUrl &hydraPrevious)
     }
     // Current hydraPrevious is still empty, setting it to the received hydraPrevious
     else {
-        qDebug() << "Empty hydraPrevious";
         m_hydraPrevious = hydraPrevious;
         emit this->hydraPreviousChanged();
     }
@@ -158,8 +154,6 @@ void RouterEngine::Journey::setHydraNext(const QUrl &hydraNext)
         QDateTime timeOldHydraNext = QDateTime::fromString(
                                          queryOldHydraNext.queryItemValue("departureTime"), Qt::ISODate);
 
-        qDebug() << "HYDRA NEXT=" << hydraNext << timeNewHydraNext << "|" << this->hydraNext() <<
-                 timeOldHydraNext;
         // Only accept URI that's later in time
         if (timeNewHydraNext > timeOldHydraNext) {
             m_hydraNext = hydraNext;
@@ -168,7 +162,6 @@ void RouterEngine::Journey::setHydraNext(const QUrl &hydraNext)
     }
     // Current hydraNext is still empty, setting it to the received hydraNext
     else {
-        qDebug() << "Empty hydraNext";
         m_hydraNext = hydraNext;
         emit this->hydraNextChanged();
     }

--- a/src/engines/router/routernulljourney.cpp
+++ b/src/engines/router/routernulljourney.cpp
@@ -14,7 +14,7 @@
  *   You should have received a copy of the GNU General Public License
  *   along with QRail.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "routernulljourney.h"
+#include "engines/router/routernulljourney.h"
 using namespace QRail;
 RouterEngine::NullJourney *RouterEngine::NullJourney::m_instance = nullptr;
 
@@ -35,10 +35,8 @@ RouterEngine::NullJourney::NullJourney(
     const QUrl &departureStation,
     const QUrl &arrivalStation,
     const quint16 &maxTransfers,
-    const QUrl &hydraPrevious,
-    const QUrl &hydraNext,
-    QObject *parent) : QObject(routes, TArray, SArray, departureStation, arrivalStation, maxTransfers,
-                                   hydraPrevious, hydraNext, parent)
+    QObject *parent) : RouterEngine::Journey(routes, TArray, SArray, departureStation, arrivalStation,
+                                                 maxTransfers, parent)
 {
 
 }
@@ -63,9 +61,7 @@ RouterEngine::NullJourney *QRail::RouterEngine::NullJourney::getInstance()
                                      QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> >(),
                                      QUrl(),
                                      QUrl(),
-                                     0,
-                                     QUrl(),
-                                     QUrl());
+                                     0);
     }
     return m_instance;
 }

--- a/src/engines/router/routernulljourney.cpp
+++ b/src/engines/router/routernulljourney.cpp
@@ -1,0 +1,71 @@
+/*
+ *   This file is part of QRail.
+ *
+ *   QRail is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   QRail is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with QRail.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "routernulljourney.h"
+using namespace QRail;
+RouterEngine::NullJourney *RouterEngine::NullJourney::m_instance = nullptr;
+
+/**
+ * @file routernulljourney.cpp
+ * @author Dylan Van Assche
+ * @date 07 Oct 2018
+ * @brief Gets a RouterEngine::NullJourney instance
+ * @return RouterEngine::NullJourney *journey
+ * @package RouterEngine
+ * @public
+ * Constructs a RouterEngine::NullJourney if none exists and returns the instance.
+ */
+RouterEngine::NullJourney::NullJourney(
+    const QList<QRail::RouterEngine::Route *> &routes,
+    const QMap<QUrl, QRail::RouterEngine::TrainProfile *> &TArray,
+    const QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> > &SArray,
+    const QUrl &departureStation,
+    const QUrl &arrivalStation,
+    const quint16 &maxTransfers,
+    const QUrl &hydraPrevious,
+    const QUrl &hydraNext,
+    QObject *parent) : QObject(routes, TArray, SArray, departureStation, arrivalStation, maxTransfers,
+                                   hydraPrevious, hydraNext, parent)
+{
+
+}
+
+/**
+ * @file routernulljourney.cpp
+ * @author Dylan Van Assche
+ * @date 07 Oct 2018
+ * @brief Gets a RouterEngine::NullJourney instance
+ * @return RouterEngine::NullJourney *journey
+ * @package RouterEngine
+ * @public
+ * Constructs a RouterEngine::NullJourney if none exists and returns the instance.
+ */
+RouterEngine::NullJourney *QRail::RouterEngine::NullJourney::getInstance()
+{
+    // Singleton pattern
+    if (m_instance == nullptr) {
+        qDebug() << "Generating new NullJourney";
+        m_instance = new NullJourney(QList<QRail::RouterEngine::Route *>(),
+                                     QMap<QUrl, QRail::RouterEngine::TrainProfile *>(),
+                                     QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> >(),
+                                     QUrl(),
+                                     QUrl(),
+                                     0,
+                                     QUrl(),
+                                     QUrl());
+    }
+    return m_instance;
+}

--- a/src/engines/router/routerplanner.cpp
+++ b/src/engines/router/routerplanner.cpp
@@ -122,6 +122,13 @@ void QRail::RouterEngine::Planner::getConnections(const QUrl &departureStation,
         this->setMaxTransfers(maxTransfers);
         this->setRoutes(QList<QRail::RouterEngine::Route *>());
         this->initUsedPages();
+        this->setJourney(new QRail::RouterEngine::Journey());
+        this->journey()->setTArray(QMap<QUrl, QRail::RouterEngine::TrainProfile *>());
+        this->journey()->setSArray(QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *>>());
+        this->journey()->setDepartureStation(departureStation);
+        this->journey()->setArrivalStation(arrivalStation);
+        this->journey()->setMaxTransfers(maxTransfers);
+        this->journey()->setRoutes(QList<QRail::RouterEngine::Route *>());
 
         /*
          * Setup footpaths for the arrival station since CSA profile
@@ -235,6 +242,10 @@ void QRail::RouterEngine::Planner::parsePage(QRail::Fragments::Page *page)
     qDebug() << "\tArrival time:" << this->arrivalTime();
     qDebug() << "\tmaxTransfers:" << this->maxTransfers();
 #endif
+
+    // Update hydraPrevious and hydraNext pointers
+    this->journey()->setHydraNext(page->hydraNext());
+    this->journey()->setHydraPrevious(page->hydraPrevious());
 
     // Keep a reference to this page for later deletion
     this->addToUsedPages(page);
@@ -887,9 +898,8 @@ void QRail::RouterEngine::Planner::parsePage(QRail::Fragments::Page *page)
                                                                                  this->SArray(),
                                                                                  this->departureStationURI(),
                                                                                  this->arrivalStationURI(),
-                                                                                 this->maxTransfers(),
-                                                                                 this->hydraPrevious(),
-                                                                                 this->hydraNext());
+                                                                                 this->maxTransfers());
+        emit this->finished(journey);
 
         // Clean up pages when we're finished
         this->deleteUsedPages();
@@ -1369,4 +1379,14 @@ void QRail::RouterEngine::Planner::setSArray(const
                                              QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *>> &SArray)
 {
     m_SArray = SArray;
+}
+
+QRail::RouterEngine::Journey *RouterEngine::Planner::journey() const
+{
+    return m_journey;
+}
+
+void RouterEngine::Planner::setJourney(QRail::RouterEngine::Journey *journey)
+{
+    m_journey = journey;
 }

--- a/src/engines/router/routerplanner.cpp
+++ b/src/engines/router/routerplanner.cpp
@@ -173,7 +173,7 @@ void QRail::RouterEngine::Planner::getConnections(const QUrl &departureStation,
  * a maximum of transfers. Emit the finished signal when completed, the error
  * signal is emitted in case an error comes up.
  *
- * Invalid input will directly emit the finished signal with an empty list.
+ * Invalid input will directly emit the finished signal with a NullJourney instance.
  */
 void RouterEngine::Planner::getConnections(const QGeoCoordinate &departurePosition,
                                            const QGeoCoordinate &arrivalPosition,
@@ -191,7 +191,7 @@ void RouterEngine::Planner::getConnections(const QGeoCoordinate &departurePositi
         qCritical() << "Departure position:" << departurePosition;
         qCritical() << "Arrival position:" << arrivalPosition;
         qCritical() << "Departure time:" << departureTime;
-        emit this->finished(QList<QRail::RouterEngine::Route *>());
+        emit this->finished(QRail::RouterEngine::NullJourney::getInstance());
     }
 }
 
@@ -881,7 +881,15 @@ void QRail::RouterEngine::Planner::parsePage(QRail::Fragments::Page *page)
         }
 
         // Emit finished signal when we completely parsed and processed all Linked Connections pages
-        emit this->finished(this->routes());
+        //emit this->finished(this->routes());
+        QRail::RouterEngine::Journey *journey = new QRail::RouterEngine::Journey(this->routes(),
+                                                                                 this->TArray(),
+                                                                                 this->SArray(),
+                                                                                 this->departureStationURI(),
+                                                                                 this->arrivalStationURI(),
+                                                                                 this->maxTransfers(),
+                                                                                 this->hydraPrevious(),
+                                                                                 this->hydraNext());
 
         // Clean up pages when we're finished
         this->deleteUsedPages();

--- a/src/include/engines/liveboard/liveboardnullboard.h
+++ b/src/include/engines/liveboard/liveboardnullboard.h
@@ -35,11 +35,11 @@ public:
     static NullBoard *getInstance();
 
 private:
-    NullBoard(const QList<QRail::VehicleEngine::Vehicle *> &entries,
-              StationEngine::Station *station,
-              const QDateTime &from,
-              const QDateTime &until,
-              QObject *parent = nullptr);
+    explicit NullBoard(const QList<QRail::VehicleEngine::Vehicle *> &entries,
+                       StationEngine::Station *station,
+                       const QDateTime &from,
+                       const QDateTime &until,
+                       QObject *parent = nullptr);
     static LiveboardEngine::NullBoard *m_instance;
 };
 }

--- a/src/include/engines/router/routerjourney.cpp
+++ b/src/include/engines/router/routerjourney.cpp
@@ -1,0 +1,135 @@
+/*
+ *   This file is part of QRail.
+ *
+ *   QRail is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   QRail is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with QRail.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "routerjourney.h"
+using namespace QRail;
+
+RouterEngine::Journey::Journey(QObject *parent) : QObject(parent)
+{
+
+}
+
+RouterEngine::Journey::Journey(const QList<RouterEngine::Route *> &routes,
+                               const QMap<QUrl, RouterEngine::TrainProfile *> &TArray,
+                               const QMap<QUrl, QList<RouterEngine::StationStopProfile *> > &SArray,
+                               const QUrl &departureStation,
+                               const QUrl &arrivalStation,
+                               const quint16 &maxTransfers,
+                               const QUrl &hydraPrevious,
+                               const QUrl &hydraNext,
+                               QObject *parent) : QObject(parent)
+{
+    // Use private members to avoid signal firing on construction
+    m_routes = routes;
+    m_TArray = TArray;
+    m_SArray = SArray;
+    m_departureStation = departureStation;
+    m_arrivalStation = arrivalStation;
+    m_maxTransfers = maxTransfers;
+    m_hydraPrevious = hydraPrevious;
+    m_hydraNext = hydraNext;
+}
+
+// Getters & Setters
+QList<QRail::RouterEngine::Route *> RouterEngine::Journey::routes() const
+{
+    return m_routes;
+}
+
+void RouterEngine::Journey::setRoutes(const QList<QRail::RouterEngine::Route *> &routes)
+{
+    m_routes = routes;
+    emit this->routesChanged();
+}
+
+QMap<QUrl, QRail::RouterEngine::TrainProfile *> RouterEngine::Journey::TArray() const
+{
+    return m_TArray;
+}
+
+void RouterEngine::Journey::setTArray(const QMap<QUrl, QRail::RouterEngine::TrainProfile *>
+                                      &TArray)
+{
+    m_TArray = TArray;
+    emit this->TArrayChanged();
+}
+
+QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> > RouterEngine::Journey::SArray() const
+{
+    return m_SArray;
+}
+
+void RouterEngine::Journey::setSArray(const
+                                      QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> > &SArray)
+{
+    m_SArray = SArray;
+    emit this->SArrayChanged();
+}
+
+QUrl RouterEngine::Journey::departureStation() const
+{
+    return m_departureStation;
+}
+
+void RouterEngine::Journey::setDepartureStation(const QUrl &departureStation)
+{
+    m_departureStation = departureStation;
+    emit this->departureStationChanged();
+}
+
+QUrl RouterEngine::Journey::arrivalStation() const
+{
+    return m_arrivalStation;
+}
+
+void RouterEngine::Journey::setArrivalStation(const QUrl &arrivalStation)
+{
+    m_arrivalStation = arrivalStation;
+    emit this->arrivalStationChanged();
+}
+
+quint16 RouterEngine::Journey::maxTransfers() const
+{
+    return m_maxTransfers;
+}
+
+void RouterEngine::Journey::setMaxTransfers(const quint16 &maxTransfers)
+{
+    m_maxTransfers = maxTransfers;
+    emit this->maxTransfersChanged();
+}
+
+QUrl RouterEngine::Journey::hydraPrevious() const
+{
+    return m_hydraPrevious;
+}
+
+void RouterEngine::Journey::setHydraPrevious(const QUrl &hydraPrevious)
+{
+    m_hydraPrevious = hydraPrevious;
+    emit this->hydraPreviousChanged();
+}
+
+QUrl RouterEngine::Journey::hydraNext() const
+{
+    return m_hydraNext;
+}
+
+void RouterEngine::Journey::setHydraNext(const QUrl &hydraNext)
+{
+    m_hydraNext = hydraNext;
+    emit this->hydraNextChanged();
+}

--- a/src/include/engines/router/routerjourney.h
+++ b/src/include/engines/router/routerjourney.h
@@ -21,6 +21,8 @@
 #include <QtCore/QList>
 #include <QtCore/QUrl>
 #include <QtCore/QMap>
+#include <QtCore/QDateTime>
+#include <QtCore/QUrlQuery>
 
 #include "engines/router/routerroute.h"
 #include "engines/router/routerstationstopprofile.h"
@@ -39,8 +41,6 @@ public:
                      const QUrl &departureStation,
                      const QUrl &arrivalStation,
                      const quint16 &maxTransfers,
-                     const QUrl &hydraPrevious,
-                     const QUrl &hydraNext,
                      QObject *parent = nullptr);
     QList<QRail::RouterEngine::Route *> routes() const;
     void setRoutes(const QList<QRail::RouterEngine::Route *> &routes);

--- a/src/include/engines/router/routerjourney.h
+++ b/src/include/engines/router/routerjourney.h
@@ -1,0 +1,85 @@
+/*
+ *   This file is part of QRail.
+ *
+ *   QRail is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   QRail is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with QRail.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef ROUTERJOURNEY_H
+#define ROUTERJOURNEY_H
+
+#include <QtCore/QObject>
+#include <QtCore/QList>
+#include <QtCore/QUrl>
+#include <QtCore/QMap>
+
+#include "engines/router/routerroute.h"
+#include "engines/router/routerstationstopprofile.h"
+#include "engines/router/routertrainprofile.h"
+
+namespace QRail {
+namespace RouterEngine {
+class Journey : public QObject
+{
+    Q_OBJECT
+public:
+    explicit Journey(QObject *parent = nullptr);
+    explicit Journey(const QList<QRail::RouterEngine::Route *> &routes,
+                     const QMap<QUrl, QRail::RouterEngine::TrainProfile *> &TArray,
+                     const QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> > &SArray,
+                     const QUrl &departureStation,
+                     const QUrl &arrivalStation,
+                     const quint16 &maxTransfers,
+                     const QUrl &hydraPrevious,
+                     const QUrl &hydraNext,
+                     QObject *parent = nullptr);
+    QList<QRail::RouterEngine::Route *> routes() const;
+    void setRoutes(const QList<QRail::RouterEngine::Route *> &routes);
+    QMap<QUrl, QRail::RouterEngine::TrainProfile *> TArray() const;
+    void setTArray(const QMap<QUrl, QRail::RouterEngine::TrainProfile *> &TArray);
+    QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> > SArray() const;
+    void setSArray(const QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> > &SArray);
+    QUrl departureStation() const;
+    void setDepartureStation(const QUrl &departureStation);
+    QUrl arrivalStation() const;
+    void setArrivalStation(const QUrl &arrivalStation);
+    quint16 maxTransfers() const;
+    void setMaxTransfers(const quint16 &maxTransfers);
+    QUrl hydraPrevious() const;
+    void setHydraPrevious(const QUrl &hydraPrevious);
+    QUrl hydraNext() const;
+    void setHydraNext(const QUrl &hydraNext);
+
+signals:
+    void routesChanged();
+    void TArrayChanged();
+    void SArrayChanged();
+    void departureStationChanged();
+    void arrivalStationChanged();
+    void maxTransfersChanged();
+    void hydraPreviousChanged();
+    void hydraNextChanged();
+
+private:
+    QList<QRail::RouterEngine::Route *> m_routes;
+    QMap<QUrl, QRail::RouterEngine::TrainProfile *> m_TArray;
+    QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> > m_SArray;
+    QUrl m_departureStation;
+    QUrl m_arrivalStation;
+    quint16 m_maxTransfers;
+    QUrl m_hydraPrevious;
+    QUrl m_hydraNext;
+};
+}
+}
+
+#endif // ROUTERJOURNEY_H

--- a/src/include/engines/router/routernulljourney.h
+++ b/src/include/engines/router/routernulljourney.h
@@ -34,8 +34,6 @@ private:
                          const QUrl &departureStation,
                          const QUrl &arrivalStation,
                          const quint16 &maxTransfers,
-                         const QUrl &hydraPrevious,
-                         const QUrl &hydraNext,
                          QObject *parent = nullptr);
     static RouterEngine::NullJourney *m_instance;
 };

--- a/src/include/engines/router/routernulljourney.h
+++ b/src/include/engines/router/routernulljourney.h
@@ -1,0 +1,45 @@
+/*
+ *   This file is part of QRail.
+ *
+ *   QRail is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   QRail is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with QRail.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef ROUTERNULLJOURNEY_H
+#define ROUTERNULLJOURNEY_H
+
+#include "engines/router/routerjourney.h"
+#include "qrail.h"
+
+namespace QRail {
+namespace RouterEngine {
+class QRAIL_SHARED_EXPORT NullJourney : public RouterEngine::Journey
+{
+public:
+    static NullJourney *getInstance();
+
+private:
+    explicit NullJourney(const QList<QRail::RouterEngine::Route *> &routes,
+                         const QMap<QUrl, QRail::RouterEngine::TrainProfile *> &TArray,
+                         const QMap<QUrl, QList<QRail::RouterEngine::StationStopProfile *> > &SArray,
+                         const QUrl &departureStation,
+                         const QUrl &arrivalStation,
+                         const quint16 &maxTransfers,
+                         const QUrl &hydraPrevious,
+                         const QUrl &hydraNext,
+                         QObject *parent = nullptr);
+    static RouterEngine::NullJourney *m_instance;
+};
+}
+}
+
+#endif // ROUTERNULLJOURNEY_H

--- a/src/include/engines/router/routerplanner.h
+++ b/src/include/engines/router/routerplanner.h
@@ -112,6 +112,7 @@ private:
     QMap<QUrl, QRail::RouterEngine::TrainProfile *> m_TArray;
     QMap<QUrl, qreal> m_DArray;
     QList<QRail::Fragments::Page *> m_usedPages;
+    QRail::RouterEngine::Journey *m_journey;
     explicit Planner(QObject *parent = nullptr);
     static QRail::RouterEngine::Planner *m_instance;
     void parsePage(QRail::Fragments::Page *page);
@@ -137,6 +138,8 @@ private:
     void setMaxTransfers(const qint16 &maxTransfers);
     void setDepartureStationURI(const QUrl &departureStationURI);
     void setArrivalStationURI(const QUrl &arrivalStationURI);
+    QRail::RouterEngine::Journey *journey() const;
+    void setJourney(QRail::RouterEngine::Journey *journey);
 };
 } // namespace RouterEngine
 } // namespace QRail

--- a/src/include/engines/router/routerplanner.h
+++ b/src/include/engines/router/routerplanner.h
@@ -37,6 +37,8 @@
 #include "engines/router/routerstationstopprofile.h"
 #include "engines/router/routertrainprofile.h"
 #include "engines/router/routertransfer.h"
+#include "engines/router/routerjourney.h"
+#include "engines/router/routernulljourney.h"
 #include "engines/station/stationfactory.h"
 #include "engines/station/stationstation.h"
 #include "fragments/fragmentsfactory.h"
@@ -89,7 +91,7 @@ protected:
     virtual void customEvent(QEvent *event);
 
 signals:
-    void finished(const QList<QRail::RouterEngine::Route *> &routes);
+    void finished(QRail::RouterEngine::Journey *journey);
     void stream(QRail::RouterEngine::Route *route);
     void error(const QString &message);
     void requested(const QUrl &pageURI);

--- a/tests/src/engines/router/routerplannertest.cpp
+++ b/tests/src/engines/router/routerplannertest.cpp
@@ -52,7 +52,6 @@ void QRail::RouterEngine::PlannerTest::runCSAPlannerTest()
     * https://lc2irail.thesis.bertmarcelis.be/connections/008811189/008891009/departing/2018-08-02T13:00:00+00:00
     */
 
-
     QDateTime start = QDateTime::currentDateTime();
     planner->getConnections(
         QUrl("http://irail.be/stations/NMBS/008811189"), // From: Vilvoorde

--- a/tests/src/engines/router/routerplannertest.cpp
+++ b/tests/src/engines/router/routerplannertest.cpp
@@ -87,24 +87,8 @@ void QRail::RouterEngine::PlannerTest::cleanCSAPlannerTest()
 
 void RouterEngine::PlannerTest::processRoutesFinished(RouterEngine::Journey *journey)
 {
-    qDebug() << "JOURNEY OK";
-}
-
-void QRail::RouterEngine::PlannerTest::processing(const QUrl &pageURI)
-{
-    qDebug() << "Page received:" << pageURI.toString();
-}
-
-void QRail::RouterEngine::PlannerTest::requested(const QUrl &pageURI)
-{
-    qDebug() << "Page requested:" << pageURI.toString();
-}
-
-/*void QRail::RouterEngine::PlannerTest::processRoutesFinished(const
-                                                             QList<QRail::RouterEngine::Route *>
-                                                             &routes)
-{
-    qDebug() << "CSA found" << routes.size() << "possible routes";
+    qDebug() << "Journey calculation finished, found" << journey->routes().length() << "routes";
+    QList<QRail::RouterEngine::Route *> routes = journey->routes();
     foreach (QRail::RouterEngine::Route *route, routes) {
         // Verify the complete trip
         qDebug() << "Trip:" << route->departureStation()->station()->name().value(
@@ -145,8 +129,17 @@ void QRail::RouterEngine::PlannerTest::requested(const QUrl &pageURI)
             }
         }
     }
-    qDebug() << "All routes processed";
-}*/
+}
+
+void QRail::RouterEngine::PlannerTest::processing(const QUrl &pageURI)
+{
+    qDebug() << "Page received:" << pageURI.toString();
+}
+
+void QRail::RouterEngine::PlannerTest::requested(const QUrl &pageURI)
+{
+    qDebug() << "Page requested:" << pageURI.toString();
+}
 
 void RouterEngine::PlannerTest::processRoutesStream(QRail::RouterEngine::Route *route)
 {

--- a/tests/src/engines/router/routerplannertest.cpp
+++ b/tests/src/engines/router/routerplannertest.cpp
@@ -19,6 +19,8 @@ using namespace QRail;
 
 void QRail::RouterEngine::PlannerTest::initCSAPlannerTest()
 {
+    qInfo() << "Init PlannerTest";
+
     // Get a Planner instance
     planner = QRail::RouterEngine::Planner::getInstance();
 
@@ -26,8 +28,8 @@ void QRail::RouterEngine::PlannerTest::initCSAPlannerTest()
     qRegisterMetaType<QList<QRail::RouterEngine::Route *>>("QList<QRail::RouterEngine::Route*>");
 
     // Connect the signals
-    connect(planner, SIGNAL(finished(QList<QRail::RouterEngine::Route *>)), this,
-            SLOT(processRoutesFinished(QList<QRail::RouterEngine::Route *>)));
+    connect(planner, SIGNAL(finished(QRail::RouterEngine::Journey *)), this,
+            SLOT(processRoutesFinished(QRail::RouterEngine::Journey *)));
     connect(planner, SIGNAL(stream(QRail::RouterEngine::Route *)), this,
             SLOT(processRoutesStream(QRail::RouterEngine::Route *)));
     connect(planner, SIGNAL(processing(QUrl)), this, SLOT(processing(QUrl)));
@@ -36,6 +38,7 @@ void QRail::RouterEngine::PlannerTest::initCSAPlannerTest()
 
 void QRail::RouterEngine::PlannerTest::runCSAPlannerTest()
 {
+    qInfo() << "Running PlannerTest";
     /*
     * Guess the arrival time given a departure time.
     * The arrival time must come after the departure time to be valid.
@@ -62,7 +65,7 @@ void QRail::RouterEngine::PlannerTest::runCSAPlannerTest()
 
     // Start an eventloop to wait for the finished signal to allow benchmarking of asynchronous events
     QEventLoop loop;
-    connect(planner, SIGNAL(finished(QList<QRail::RouterEngine::Route *>)), &loop, SLOT(quit()));
+    connect(planner, SIGNAL(finished(QRail::RouterEngine::Journey *)), &loop, SLOT(quit()));
     loop.exec();
     qInfo() << "Routing Vilvoorde -> Brugge took"
             << start.msecsTo(QDateTime::currentDateTime())
@@ -71,14 +74,20 @@ void QRail::RouterEngine::PlannerTest::runCSAPlannerTest()
 
 void QRail::RouterEngine::PlannerTest::cleanCSAPlannerTest()
 {
-    disconnect(planner, SIGNAL(finished(QList<QRail::RouterEngine::Route *>)),
-               this, SLOT(processRoutesFinished(QList<QRail::RouterEngine::Route *>)));
+    qInfo() << "Cleaning up PlannerTest";
+    disconnect(planner, SIGNAL(finished(QRail::RouterEngine::Journey *)),
+               this, SLOT(processRoutesFinished(QRail::RouterEngine::Journey *)));
     disconnect(planner, SIGNAL(processing(QUrl)),
                this, SLOT(processing(QUrl)));
     disconnect(planner, SIGNAL(requested(QUrl)),
                this, SLOT(requested(QUrl)));
     disconnect(planner, SIGNAL(stream(QRail::RouterEngine::Route *)),
                this, SLOT(processRoutesStream(QRail::RouterEngine::Route *)));
+}
+
+void RouterEngine::PlannerTest::processRoutesFinished(RouterEngine::Journey *journey)
+{
+    qDebug() << "JOURNEY OK";
 }
 
 void QRail::RouterEngine::PlannerTest::processing(const QUrl &pageURI)
@@ -91,7 +100,7 @@ void QRail::RouterEngine::PlannerTest::requested(const QUrl &pageURI)
     qDebug() << "Page requested:" << pageURI.toString();
 }
 
-void QRail::RouterEngine::PlannerTest::processRoutesFinished(const
+/*void QRail::RouterEngine::PlannerTest::processRoutesFinished(const
                                                              QList<QRail::RouterEngine::Route *>
                                                              &routes)
 {
@@ -137,7 +146,7 @@ void QRail::RouterEngine::PlannerTest::processRoutesFinished(const
         }
     }
     qDebug() << "All routes processed";
-}
+}*/
 
 void RouterEngine::PlannerTest::processRoutesStream(QRail::RouterEngine::Route *route)
 {

--- a/tests/src/engines/router/routerplannertest.h
+++ b/tests/src/engines/router/routerplannertest.h
@@ -35,7 +35,7 @@ private slots:
     void cleanCSAPlannerTest();
 
 public slots:
-    void processRoutesFinished(const QList<QRail::RouterEngine::Route *> &routes);
+    void processRoutesFinished(QRail::RouterEngine::Journey *journey);
     void processRoutesStream(QRail::RouterEngine::Route *route);
     void processing(const QUrl &pageURI);
     void requested(const QUrl &pageURI);

--- a/tests/src/qrail-tests.cpp
+++ b/tests/src/qrail-tests.cpp
@@ -69,16 +69,16 @@ int main(int argc, char *argv[])
         lcPageResult = QTest::qExec(&testSuiteLCPage, 0, nullptr);
 
         // Run QRail::LiveboardEngine::Factory integration test
-        liveboardFactoryResult = QTest::qExec(&testSuiteLiveboardFactory, 0, nullptr);
-
-        // Run QRail::RouterEngine::Planner integration test
-        routerPlannerResult = QTest::qExec(&testSuiteCSAPlanner, 0, nullptr);
-
-        // Run QRail::LiveboardEngine::Factory integration test
         vehicleFactoryResult = QTest::qExec(&testSuiteVehicleFactory, 0, nullptr);
 
         // Run QRail::StationEngine::Factory integration test
         stationFactoryResult = QTest::qExec(&testSuiteStationFactory, 0, nullptr);
+
+        // Run QRail::LiveboardEngine::Factory integration test
+        liveboardFactoryResult = QTest::qExec(&testSuiteLiveboardFactory, 0, nullptr);
+
+        // Run QRail::RouterEngine::Planner integration test
+        routerPlannerResult = QTest::qExec(&testSuiteCSAPlanner, 0, nullptr);
 
         // Return the status code of every test for CI/CD
         QCoreApplication::exit(networkManagerResult | dbManagerResult | lcFragmentResult | lcPageResult |


### PR DESCRIPTION
1. **Explanation**: 
    - Enable nextResults() and previousResults() in routing

2. **Fixed issues**: 
    - Fixed #64

3. **Testing environment**: 
    - Sailfish OS version: 2.1.1.18
    - Sailfish OS hardware: Xperia X
